### PR TITLE
Conditionally require modern setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas==2.0.3
 numpy==1.24.4
 apscheduler==3.10.4
 wheel
+setuptools>=69; python_version >= "3.12"


### PR DESCRIPTION
## Summary
- Require `setuptools>=69` only when running on Python 3.12 or newer to avoid build failures on older versions

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py scanner.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbb4b33b2c832da000372d26046328