### PR TITLE
Use core uvicorn package and conditionally require modern setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 fastapi==0.111.0
-uvicorn[standard]==0.30.0
+# Use the core uvicorn package to avoid build issues with optional extras
+uvicorn==0.30.0
 requests==2.32.3
 pandas==2.0.3
 numpy==1.24.4
 apscheduler==3.10.4
 wheel
+setuptools>=69; python_version >= "3.12"


### PR DESCRIPTION
## Summary
- Drop the `[standard]` extra and depend on the base `uvicorn` package to prevent requirement parsing errors
- Keep requiring `setuptools>=69` only for Python 3.12+ environments

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python -m py_compile app.py scanner.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbb4b33b2c832da000372d26046328